### PR TITLE
Change tab links in the columns to lowercase

### DIFF
--- a/src/Tables/LocalesColumn.php
+++ b/src/Tables/LocalesColumn.php
@@ -4,6 +4,7 @@ namespace Codedor\TranslatableTabs\Tables;
 
 use Closure;
 use Filament\Tables\Columns\Column;
+use Illuminate\Support\Str;
 
 class LocalesColumn extends Column
 {
@@ -40,9 +41,11 @@ class LocalesColumn extends Column
         $resource = $livewire::getResource();
 
         /** @var \Filament\Resources\Resource $resource */
-        return $resource::getUrl($this->resourceAction, [
+        $url = $resource::getUrl($this->resourceAction, [
             'record' => $this->getRecord(),
             'locale' => "-{$locale}-tab",
         ]);
+
+        return Str::lower($url);
     }
 }


### PR DESCRIPTION
Some locales have uppercase in them (nl-BE) but when clicking on the column link, it needs to be lowercase, otherwise the link does not work