### PR TITLE
fix cancel button; refs #THS-89

### DIFF
--- a/src/Resources/Traits/HasTranslations.php
+++ b/src/Resources/Traits/HasTranslations.php
@@ -2,7 +2,9 @@
 
 namespace Codedor\TranslatableTabs\Resources\Traits;
 
+use Filament\Actions\Action;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Js;
 
 trait HasTranslations
 {
@@ -44,5 +46,13 @@ trait HasTranslations
         }
 
         return $data;
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return Action::make('cancel')
+            ->label(__('filament-panels::resources/pages/edit-record.form.actions.cancel.label'))
+            ->alpineClickHandler('(window.location.href = ' . Js::from($this->previousUrl ?? static::getResource()::getUrl()) . ')')
+            ->color('gray');
     }
 }


### PR DESCRIPTION
Switching tabs changes the URL.
Default Filament cancel button behavior is:
            `->alpineClickHandler('document.referrer ? window.history.back() : (window.location.href = ' . Js::from($this->previousUrl ?? static::getResource()::getUrl()) . ')')`
Which makes it go back through your window history, so back 1 tab per cancel click.

By changing it to             `->alpineClickHandler((window.location.href = ' . Js::from($this->previousUrl ?? static::getResource()::getUrl()) . ')')` we get redirected to the index page when clicking the cancel button as intended, no matter which tab we're in.
