### PR TITLE
Fix an issue when removing a language

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ public static function form(Form $form): Form
                     ->required()
                     ->maxLength(255),
             ])
+            ->extraTabs([ // Optional
+                Tab::make('More things')->schema([
+                    TextInput::make('more_things')
+                        ->required()
+                        ->maxLength(255),
+                ]),
+            ])
             ->translatableFields([
                 TextInput::make("title")
                     ->label('Title')

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,7 +129,7 @@ public static function form(Form $form): Form
     return $form->schema([
         TranslatableTabs::make('Translations')
             ->defaultFields(...)
-            ->extraFields([
+            ->extraTabs([
                 Tab::make('More options')->schema([
                     Text::make('Extra option')
                         ->required(), 

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,6 +115,32 @@ TranslatableEntry::make([
 ], \App\CustomLocaleCollection::class);
 ```
 
+### Adding extra tabs
+
+You can add extra tabs by using the `->extraTabs()` method, this expects a Closure, array or `null`.
+Passing an array here with Tabs will add them next to the general tab, this can be useful for separating your General tab in case it becomes too long.
+
+```php
+use Codedor\TranslatableTabs\Forms\TranslatableTabs;
+use Filament\Forms\Components\Tabs\Tab;
+
+public static function form(Form $form): Form
+{
+    return $form->schema([
+        TranslatableTabs::make('Translations')
+            ->defaultFields(...)
+            ->extraFields([
+                Tab::make('More options')->schema([
+                    Text::make('Extra option')
+                        ->required(), 
+                ]),
+            ])
+            ->translatableFields(...)
+            ->columnSpan(['lg' => 2]),
+    ]);
+}
+```
+
 ### Showing a different icon
 
 You can show a different icon by using the `icon()` method, this expects a Closure, string or `false`.

--- a/src/Forms/TranslatableTabs.php
+++ b/src/Forms/TranslatableTabs.php
@@ -25,6 +25,8 @@ class TranslatableTabs extends Component
 
     public array|Closure $defaultFields = [];
 
+    public null|array|Closure $extraTabs = null;
+
     public Closure $translatableFields;
 
     public array|Closure $locales = [];
@@ -75,6 +77,13 @@ class TranslatableTabs extends Component
         return $this;
     }
 
+    public function extraTabs(null|array|Closure $extraTabs): static
+    {
+        $this->extraTabs = $extraTabs;
+
+        return $this;
+    }
+
     public function translatableFields(Closure $translatableFields): static
     {
         $this->translatableFields = $translatableFields;
@@ -121,6 +130,10 @@ class TranslatableTabs extends Component
             Tab::make('Default')
                 ->schema($this->evaluate($this->defaultFields)),
         ];
+
+        if (! is_null($this->extraTabs)) {
+            $tabs = array_merge($tabs, $this->evaluate($this->extraTabs));
+        }
 
         foreach ($this->evaluate($this->locales) as $locale) {
             $tabs[] = Tab::make($locale)

--- a/src/Resources/Traits/HasTranslations.php
+++ b/src/Resources/Traits/HasTranslations.php
@@ -20,7 +20,8 @@ trait HasTranslations
     {
         $record = $this->getRecord();
         foreach ($record->getTranslatableAttributes() as $field) {
-            foreach ($record->getTranslatedLocales($field) as $locale) {
+            $locales = array_keys($record->getTranslations($field, config('translatable.allowed-locales', null)));
+            foreach ($locales as $locale) {
                 $data[$locale][$field] = $record->getTranslation($field, $locale);
             }
         }


### PR DESCRIPTION
After removing a language, Architect breaks the edit page
With this update, you can set a config to only allow certain locales in the tabs

```php
config(['translatable.allowed-locales' => LocaleCollection::values()->map->locale()->toArray()]);
```