### PR TITLE
Fix tabs when not using models - refs #INF001-71

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,10 +9,6 @@ parameters:
             count: 2
             path: src/Actions/CopyTranslationAction.php
         -
-            message: "#^Call to an undefined method Livewire\\\\Component\\:\\:getRecord\\(\\)\\.$#"
-            count: 1
-            path: src/Forms/TranslatableTabs.php
-        -
             message: "#^Cannot call method getTranslatedLocales\\(\\)\\ on class-string\\|object\\.$#"
             count: 1
             path: src/Forms/TranslatableTabs.php

--- a/src/Forms/TranslatableTabs.php
+++ b/src/Forms/TranslatableTabs.php
@@ -48,7 +48,7 @@ class TranslatableTabs extends Component
                 return;
             }
 
-            $record = $livewire->getRecord();
+            $record = method_exists($livewire, 'getRecord') ? $livewire->getRecord() : null;
 
             if (! $record || ! method_exists($record, 'getTranslatableAttributes')) {
                 return;
@@ -83,6 +83,14 @@ class TranslatableTabs extends Component
         parent::dehydrateState($state, $isDehydrated);
 
         $model = app($this->getModel());
+
+        if (
+            ! $model
+            || ! method_exists($model, 'getFillable')
+            || ! method_exists($model, 'getTranslatableAttributes')
+        ) {
+            return;
+        }
 
         foreach (Arr::except($state['data'] ?? [], $model->getFillable()) as $locale => $values) {
             if (! is_array($values)) {


### PR DESCRIPTION
Fix the tabs when used in modals/pages that are not linked to a specific model, for example the Form Architect