### PR TITLE
Fix RichEditor list-item glitch in translatable tabs

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,6 @@ parameters:
             count: 1
             path: src/Forms/TranslatableTabs.php
         -
-            message: "#Trait Codedor\\\\TranslatableTabs\\\\Resources\\\\Traits\\\\HasTranslations is used zero times and is not analysed\\.$#"
+            message: "#Trait Wotz\\\\TranslatableTabs\\\\Resources\\\\Traits\\\\HasTranslations is used zero times and is not analysed\\.$#"
             count: 1
             path: src/Resources/Traits/HasTranslations.php

--- a/src/Forms/TranslatableTabs.php
+++ b/src/Forms/TranslatableTabs.php
@@ -58,9 +58,13 @@ class TranslatableTabs extends Tabs
                             $components = $livewire->form->getFlatComponents(withActions: false, withHidden: true);
 
                             if (isset($components["{$locale}.{$field}"]) && $components["{$locale}.{$field}"] instanceof RichEditor) {
-                                $value = $components["{$locale}.{$field}"]->getTipTapEditor()
-                                    ->setContent($value)
-                                    ->getDocument();
+                                // Run the editor's own state casts rather than converting through the
+                                // TipTap editor directly, so that the normalisation Filament applies
+                                // in RichEditorStateCast (list items, mention labels, file attachment
+                                // urls, ...) is not skipped.
+                                foreach ($components["{$locale}.{$field}"]->getStateCasts() as $stateCast) {
+                                    $value = $stateCast->set($value);
+                                }
                             }
                         }
                     }

--- a/src/Tables/LocalesColumn.php
+++ b/src/Tables/LocalesColumn.php
@@ -4,7 +4,6 @@ namespace Wotz\TranslatableTabs\Tables;
 
 use Closure;
 use Exception;
-use Filament\Resources\Pages\Page;
 use Filament\Tables\Columns\Column;
 use Filament\Tables\Contracts\HasTable;
 use Illuminate\Support\Str;
@@ -38,7 +37,7 @@ class LocalesColumn extends Column
 
     public function getResourceUrl(string $locale): string
     {
-        /** @var Page&HasTable $livewire */
+        /** @var HasTable $livewire */
         $livewire = $this->getLivewire();
 
         if (method_exists($livewire, 'getResource')) {

--- a/tests/Feature/Forms/TranslatableRichEditorTest.php
+++ b/tests/Feature/Forms/TranslatableRichEditorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Livewire\Livewire;
+use Wotz\TranslatableTabs\Tests\Fixtures\TestRichEditorForm;
+
+it('hydrates a translatable rich editor through the editor state casts', function () {
+    // Bare <li> text must be wrapped in a paragraph by Filament's RichEditorStateCast.
+    // Converting through the TipTap editor directly skips that normalisation and hands
+    // the JS editor a document its schema does not allow, which makes the caret jump
+    // around while editing list items. See filamentphp/filament#19529.
+    $translations = [
+        'body' => [
+            'en' => '<ul><li>First item</li><li>Second item</li></ul>',
+            'nl' => '<ul><li>Eerste item</li></ul>',
+        ],
+    ];
+
+    $state = Livewire::test(TestRichEditorForm::class, ['translations' => $translations])
+        ->get('data');
+
+    $bulletList = $state['en']['body']['content'][0];
+
+    expect($bulletList['type'])->toBe('bulletList');
+
+    foreach ($bulletList['content'] as $listItem) {
+        expect($listItem['type'])->toBe('listItem')
+            ->and($listItem['content'][0]['type'])->toBe('paragraph');
+    }
+
+    expect($bulletList['content'][0]['content'][0]['content'][0]['text'])->toBe('First item')
+        ->and($bulletList['content'][1]['content'][0]['content'][0]['text'])->toBe('Second item');
+});
+
+it('hydrates every locale of a translatable rich editor', function () {
+    $translations = [
+        'body' => [
+            'en' => '<p>English body</p>',
+            'nl' => '<p>Nederlandse tekst</p>',
+        ],
+    ];
+
+    $state = Livewire::test(TestRichEditorForm::class, ['translations' => $translations])
+        ->get('data');
+
+    expect($state['en']['body']['content'][0]['content'][0]['text'])->toBe('English body')
+        ->and($state['nl']['body']['content'][0]['content'][0]['text'])->toBe('Nederlandse tekst');
+});

--- a/tests/Fixtures/TestRecord.php
+++ b/tests/Fixtures/TestRecord.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Wotz\TranslatableTabs\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A minimal stand-in for a spatie/laravel-translatable model: TranslatableTabs only
+ * duck-types the translatable methods, so the tests do not need that dependency.
+ */
+class TestRecord extends Model
+{
+    protected $guarded = [];
+
+    public array $translations = [];
+
+    /**
+     * @return array<string>
+     */
+    public function getTranslatableAttributes(): array
+    {
+        return array_keys($this->translations);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getTranslatedLocales(string $field): array
+    {
+        return array_keys($this->translations[$field] ?? []);
+    }
+
+    public function getTranslation(string $field, string $locale): mixed
+    {
+        return $this->translations[$field][$locale] ?? null;
+    }
+}

--- a/tests/Fixtures/TestRichEditorForm.php
+++ b/tests/Fixtures/TestRichEditorForm.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Wotz\TranslatableTabs\Tests\Fixtures;
+
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Schemas\Schema;
+use Livewire\Component;
+use Wotz\TranslatableTabs\Forms\TranslatableTabs;
+
+class TestRichEditorForm extends Component implements HasSchemas
+{
+    use InteractsWithSchemas;
+
+    public ?array $data = [];
+
+    public array $translations = [];
+
+    public function mount(): void
+    {
+        $this->form->fill($this->translations);
+    }
+
+    public function getRecord(): TestRecord
+    {
+        $record = new TestRecord;
+        $record->translations = $this->translations;
+
+        return $record;
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TranslatableTabs::make()
+                    ->locales(['en', 'nl'])
+                    ->defaultFields([
+                        TextInput::make('working_title'),
+                    ])
+                    ->translatableFields(fn (string $locale) => [
+                        RichEditor::make('body'),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function render(): string
+    {
+        return <<<'HTML'
+        <div>
+            <form wire:submit="create">
+                {{ $this->form }}
+
+                <button type="submit">
+                    Submit
+                </button>
+            </form>
+
+            <x-filament-actions::modals />
+        </div>
+        HTML;
+    }
+}


### PR DESCRIPTION
The afterStateHydrated "RichEditor hack" converted stored HTML through the TipTap editor directly, bypassing RichEditorStateCast. That skipped the list-item normalisation Filament added in filamentphp/filament#19529, so bare `<li>text</li>` reached the JS editor without a paragraph wrapper and the caret jumped around while editing bullet lists. Run the editor's own state casts instead, which also preserves mention-label and file-attachment handling.